### PR TITLE
xfail two tests that don't work with aiohttp3 and mocket anymore

### DIFF
--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -174,6 +174,7 @@ async def test_error_on_missing_type_in_model(swagger_dict, sample_model, http_c
     assert "'name' is a required property" in str(excinfo.value)
 
 
+@pytest.mark.xfail(reason='Fails with aiohttp 3 due to https://github.com/mindflayer/python-mocket/issues/66')
 @pytest.mark.asyncio
 async def test_model_in_body_of_request(swagger_dict, sample_model, http_client):
     param_spec = {

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -12,6 +12,7 @@ from tests.functional.conftest import register_spec
 from tests.functional.conftest import swagger_client
 
 
+@pytest.mark.xfail(reason='Fails with aiohttp 3 due to https://github.com/mindflayer/python-mocket/issues/66')
 @pytest.mark.asyncio
 async def test_form_params_in_request(swagger_dict, http_client):
     param1_spec = {


### PR DESCRIPTION
aiohttp 3 contains a change that breaks two aiobravado tests: it does two socket writes if the request contains a body. This was done in aio-libs/aiohttp#2126 and is documented in the "Are there changes in behavior for the user?" section. Check out the [diff of the write_headers function](https://github.com/aio-libs/aiohttp/commit/bbf62184929f8f4ae36ad417005b5f9dad4d9e6a#diff-b01a901427ef6052963c0c1281a51872L241). Unfortunately, python-mocket is not able to deal with such requests and loses whatever data is sent after the headers (I filed mindflayer/python-mocket#66). I'm xfailing the tests for now.