### PR TITLE
Upgrade mocket, reenable tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bottle
 ephemeral_port_reserve
 mock
-mocket
+mocket>=2.2.0
 pip>=9.0.1 # workaround to https://github.com/pypa/pip/issues/3903
 pre-commit
 pytest

--- a/tests/functional/model_func_test.py
+++ b/tests/functional/model_func_test.py
@@ -174,7 +174,6 @@ async def test_error_on_missing_type_in_model(swagger_dict, sample_model, http_c
     assert "'name' is a required property" in str(excinfo.value)
 
 
-@pytest.mark.xfail(reason='Fails with aiohttp 3 due to https://github.com/mindflayer/python-mocket/issues/66')
 @pytest.mark.asyncio
 async def test_model_in_body_of_request(swagger_dict, sample_model, http_client):
     param_spec = {

--- a/tests/functional/request_func_test.py
+++ b/tests/functional/request_func_test.py
@@ -12,7 +12,6 @@ from tests.functional.conftest import register_spec
 from tests.functional.conftest import swagger_client
 
 
-@pytest.mark.xfail(reason='Fails with aiohttp 3 due to https://github.com/mindflayer/python-mocket/issues/66')
 @pytest.mark.asyncio
 async def test_form_params_in_request(swagger_dict, http_client):
     param1_spec = {


### PR DESCRIPTION
Thanks to mindflayer/python-mocket#67, these tests pass again; let's reenable them.