### PR TITLE
Fix test failures related to boolean param handling in bravado-core 5.0.5

### DIFF
--- a/testing/integration_server.py
+++ b/testing/integration_server.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import argparse
 import asyncio
 import os.path
@@ -20,7 +21,7 @@ async def login(request):
     if not (
         request.query.get('username') == 'asyncio'
         and request.query.get('password') == 'password'
-        and request.query.get('invalidate_sessions') == 'True'
+        and request.query.get('invalidate_sessions') in ('True', 'true')
     ):
         return web.HTTPBadRequest()
 

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -80,7 +80,13 @@ def test_with_not_string_headers(
         'files': mock.Mock(),
     })
 
-    assert request['headers'][header_name] == str(header_value)
+    expected_header_value = str(header_value)
+    # we need to handle a backwards-incompatible change in bravado-core 5.0.5
+    if swagger_type == 'boolean':
+        assert request['headers'][header_name] in (expected_header_value, expected_header_value.lower())
+    else:
+        assert request['headers'][header_name] == expected_header_value
+
     unmarshalled_request = unmarshal_request(request_object, operation)
     assert unmarshalled_request[header_name] == header_value
 


### PR DESCRIPTION
These changes are basically what we're doing with bravado as well. The coding comment was added by a pre-commit hook. I plan on reworking that in the future.