### PR TITLE
Fix pytest 4 compatibility, don't call fixture functions from code

### DIFF
--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
+from bravado_core.spec import Spec
 
-from aiobravado.client import Spec
 from aiobravado.client import SwaggerClient
 
 

--- a/tests/client/construct_request_test.py
+++ b/tests/client/construct_request_test.py
@@ -3,12 +3,18 @@ import pytest
 from bravado_core.operation import Operation
 from bravado_core.request import IncomingRequest
 from bravado_core.request import unmarshal_request
+from bravado_core.spec import Spec
 from mock import mock
 from mock import patch
 
 from aiobravado.client import CallableOperation
 from aiobravado.client import construct_request
-from tests.client.conftest import minimal_swagger_spec as build_swagger_spec
+
+
+def build_swagger_spec(swagger_dict):
+    spec = Spec(swagger_dict)
+    spec.api_url = 'http://localhost/'
+    return spec
 
 
 @pytest.mark.parametrize('timeout_kv', [


### PR DESCRIPTION
This is the same change as Yelp/bravado#396.